### PR TITLE
feat: add Python version matrix testing and update supported versions

### DIFF
--- a/.github/workflows/python_code_quality.yml
+++ b/.github/workflows/python_code_quality.yml
@@ -67,6 +67,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -82,7 +85,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install the project
         run: uv sync --all-extras --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Home Automation",
 ]
 
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12,<3.14"
 dependencies = ["pydantic~=2.9.2", "aiomqtt~=2.4.0", "pyyaml~=6.0.1"]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Add matrix strategy to CI workflow to test against both Python 3.12 and 3.13
- Update pyproject.toml to officially support Python 3.13 (>=3.12,<3.14)
- Ensures comprehensive compatibility testing across all supported Python versions

## Test plan
- [x] CI workflow runs tests against Python 3.12
- [x] CI workflow runs tests against Python 3.13
- [x] All existing tests continue to pass on both versions

🤖 Generated with [Claude Code](https://claude.ai/code)