### PR TITLE
refactor: 🔨 add DeviceType table with foreign key to GlobalDevice

### DIFF
--- a/src/private_assistant_commons/__init__.py
+++ b/src/private_assistant_commons/__init__.py
@@ -1,7 +1,7 @@
 """Common utilities and base functionalities for all skills in the Private Assistant ecosystem."""
 
 from .base_skill import BaseSkill
-from .database import GlobalDevice, Room, Skill
+from .database import DeviceType, GlobalDevice, Room, Skill
 from .intent import (
     Alert,
     ClassifiedIntent,
@@ -23,6 +23,7 @@ __all__ = [
     "BaseSkill",
     "ClassifiedIntent",
     "ClientRequest",
+    "DeviceType",
     "Entity",
     "EntityType",
     "GlobalDevice",

--- a/src/private_assistant_commons/database/__init__.py
+++ b/src/private_assistant_commons/database/__init__.py
@@ -1,8 +1,9 @@
 """Database models for the Private Assistant ecosystem."""
 
-from .models import GlobalDevice, Room, Skill
+from .models import DeviceType, GlobalDevice, Room, Skill
 
 __all__ = [
+    "DeviceType",
     "GlobalDevice",
     "Room",
     "Skill",

--- a/src/private_assistant_commons/database/models.py
+++ b/src/private_assistant_commons/database/models.py
@@ -3,9 +3,10 @@
 This module provides SQLModel table definitions for managing the global device registry
 that enables pattern-based device matching across all skills in the Private Assistant ecosystem.
 
-The registry consists of three main entities:
+The registry consists of four main entities:
 - Room: Physical locations where devices are placed
 - Skill: Skills that own and manage devices
+- DeviceType: Types of devices (e.g., light, switch, media_player)
 - GlobalDevice: Devices registered in the global registry with pattern matching support
 
 Skills can register their devices in the global registry and publish updates via MQTT
@@ -13,7 +14,7 @@ to the 'assistant/global_device_update' topic, triggering the intent engine to r
 its device cache.
 
 Example:
-    from private_assistant_commons.database import Room, Skill, GlobalDevice
+    from private_assistant_commons.database import Room, Skill, DeviceType, GlobalDevice
 
     # Create a room
     bedroom = Room(name="bedroom")
@@ -21,9 +22,12 @@ Example:
     # Create a skill
     switch_skill = Skill(name="switch-skill")
 
+    # Create a device type
+    light_type = DeviceType(name="light")
+
     # Register a device
     device = GlobalDevice(
-        type="light",
+        device_type_id=light_type.id,
         name="bedroom lamp",
         pattern=["bedroom lamp", "lamp in bedroom", "bedroom light"],
         room_id=bedroom.id,
@@ -81,6 +85,27 @@ class Skill(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=datetime.now)
 
 
+class DeviceType(SQLModel, table=True):
+    """Device type model for categorizing devices.
+
+    Device types represent categories of devices (e.g., light, switch, media_player).
+    This allows for consistent device categorization across all skills.
+
+    Attributes:
+        id: Unique identifier for the device type
+        name: Unique device type name (e.g., "light", "switch", "media_player")
+        created_at: Timestamp when the device type was created
+        updated_at: Timestamp when the device type was last modified
+    """
+
+    __tablename__ = "device_types"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    name: str = Field(unique=True, index=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
 class GlobalDevice(SQLModel, table=True):
     """Device registry model for pattern-based device matching.
 
@@ -99,7 +124,7 @@ class GlobalDevice(SQLModel, table=True):
 
     Attributes:
         id: Unique identifier for the device
-        type: Device type (e.g., "light", "switch", "media_player")
+        device_type_id: Foreign key to the device type
         name: Human-readable device name
         pattern: List of pattern strings for matching natural language commands
         room_id: Optional foreign key to the room where device is located
@@ -116,7 +141,7 @@ class GlobalDevice(SQLModel, table=True):
     __tablename__ = "global_devices"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    type: str = Field(index=True)
+    device_type_id: UUID = Field(foreign_key="device_types.id", index=True)
     name: str = Field(index=True)
     pattern: list[str] = Field(sa_column=Column(ARRAY(String)))
 

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-commons"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Replace type string field with device_type_id foreign key for better data
normalization and consistency.

- Add DeviceType model with unique device type names
- Update GlobalDevice to use device_type_id foreign key
- Update module exports to include DeviceType
- Update documentation and examples

This enables consistent device categorization across all skills.