### PR TITLE
feat: ✨ add device registry mixin with optional database dependencies [AI]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "aiomqtt~=2.4.0",
     "pyyaml~=6.0.1",
     "rich~=13.9.4",
+]
+
+[project.optional-dependencies]
+database = [
     "sqlmodel~=0.0.25",
     "asyncpg~=0.30.0",
 ]

--- a/src/private_assistant_commons/__init__.py
+++ b/src/private_assistant_commons/__init__.py
@@ -1,7 +1,6 @@
 """Common utilities and base functionalities for all skills in the Private Assistant ecosystem."""
 
 from .base_skill import BaseSkill
-from .database import DeviceType, GlobalDevice, Room, Skill
 from .intent import (
     Alert,
     ClassifiedIntent,
@@ -17,23 +16,18 @@ from .intent import (
 from .skill_config import SkillConfig
 from .skill_logger import LoggerConfig, SkillLogger
 
-# Single __all__ declaration with all public exports
 __all__ = [
     "Alert",
     "BaseSkill",
     "ClassifiedIntent",
     "ClientRequest",
-    "DeviceType",
     "Entity",
     "EntityType",
-    "GlobalDevice",
     "IntentRequest",
     "IntentType",
     "LoggerConfig",
     "RecentAction",
     "Response",
-    "Room",
-    "Skill",
     "SkillConfig",
     "SkillContext",
     "SkillLogger",

--- a/src/private_assistant_commons/database/__init__.py
+++ b/src/private_assistant_commons/database/__init__.py
@@ -1,8 +1,10 @@
 """Database models for the Private Assistant ecosystem."""
 
+from .device_registry import DeviceRegistryMixin
 from .models import DeviceType, GlobalDevice, Room, Skill
 
 __all__ = [
+    "DeviceRegistryMixin",
     "DeviceType",
     "GlobalDevice",
     "Room",

--- a/src/private_assistant_commons/database/device_registry.py
+++ b/src/private_assistant_commons/database/device_registry.py
@@ -1,0 +1,251 @@
+"""Device registry mixin for standardized device CRUD operations.
+
+This module provides the DeviceRegistryMixin for skills to manage their devices
+with consistent patterns and automatic MQTT cache invalidation notifications.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from private_assistant_commons.database.models import GlobalDevice
+
+if TYPE_CHECKING:
+    import logging
+
+    import aiomqtt
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+    from private_assistant_commons.skill_config import SkillConfig
+
+
+class DeviceRegistryMixin:
+    """Mixin for skills to manage devices with standardized patterns.
+
+    Provides consistent device CRUD operations with automatic MQTT notifications
+    for cache invalidation in the intent engine.
+
+    Required attributes in class using this mixin:
+    - engine: AsyncEngine (from BaseSkill.engine property)
+    - mqtt_client: aiomqtt.Client (from BaseSkill)
+    - config_obj: SkillConfig with skill_id property
+    - logger: logging.Logger (from BaseSkill)
+
+    Example:
+        ```python
+        from sqlalchemy.ext.asyncio import create_async_engine
+        from private_assistant_commons import BaseSkill, DeviceRegistryMixin
+
+        class SwitchSkill(BaseSkill, DeviceRegistryMixin):
+            def __init__(self, ...):
+                engine = create_async_engine("postgresql+asyncpg://...")
+                super().__init__(..., engine=engine)
+
+            async def refresh_devices(self):
+                # Register a device with skill-specific metadata
+                await self.register_device(
+                    name="bedroom lamp",
+                    device_type_id=light_type_id,
+                    pattern=["bedroom lamp", "lamp in bedroom", "bedroom light"],
+                    device_attributes={
+                        "mqtt_path": "zigbee2mqtt/bedroom_lamp",
+                        "on_payload": {"state": "ON"},
+                        "off_payload": {"state": "OFF"},
+                    },
+                    room_id=bedroom_id,
+                )
+        ```
+    """
+
+    # Required attributes (provided by BaseSkill):
+    # These are declared here for type checking but will be overridden by BaseSkill
+    if TYPE_CHECKING:
+        @property
+        def engine(self) -> "AsyncEngine": ...
+        mqtt_client: "aiomqtt.Client"
+        logger: "logging.Logger"
+        config_obj: "SkillConfig"
+
+    async def register_device(
+        self,
+        name: str,
+        device_type_id: UUID,
+        pattern: list[str],
+        device_attributes: dict[str, Any] | None = None,
+        room_id: UUID | None = None,
+    ) -> GlobalDevice | None:
+        """Register a new device and publish MQTT notification.
+
+        Args:
+            name: Human-readable device name
+            device_type_id: Foreign key to DeviceType
+            pattern: List of pattern strings for NLU matching
+            device_attributes: Skill-specific metadata (MQTT paths, templates, etc.)
+            room_id: Optional foreign key to Room
+
+        Returns:
+            Created GlobalDevice instance, or None if registration failed
+        """
+        try:
+            # Convert skill_id to UUID (skill_id from config is a string)
+            skill_uuid = (
+                UUID(self.config_obj.skill_id)
+                if isinstance(self.config_obj.skill_id, str)
+                else self.config_obj.skill_id
+            )
+
+            async with AsyncSession(self.engine) as session:
+                device = GlobalDevice(
+                    name=name,
+                    device_type_id=device_type_id,
+                    pattern=pattern,
+                    device_attributes=device_attributes,
+                    room_id=room_id,
+                    skill_id=skill_uuid,
+                )
+                session.add(device)
+                await session.commit()
+                await session.refresh(device)
+
+            # Guaranteed MQTT notification for cache invalidation
+            await self._publish_device_update()
+            self.logger.info("Registered device '%s' (id=%s)", name, device.id)
+            return device
+
+        except Exception as e:
+            self.logger.error("Failed to register device '%s': %s", name, e, exc_info=True)
+            return None
+
+    async def update_device(
+        self,
+        device_id: UUID,
+        **updates: Any,
+    ) -> GlobalDevice | None:
+        """Update device fields and publish MQTT notification.
+
+        Args:
+            device_id: Device UUID to update
+            **updates: Fields to update (name, pattern, device_attributes, room_id)
+
+        Returns:
+            Updated GlobalDevice instance, or None if update failed or device not found
+        """
+        try:
+            # Convert skill_id to UUID (skill_id from config is a string)
+            skill_uuid = (
+                UUID(self.config_obj.skill_id)
+                if isinstance(self.config_obj.skill_id, str)
+                else self.config_obj.skill_id
+            )
+
+            async with AsyncSession(self.engine) as session:
+                result = await session.execute(
+                    select(GlobalDevice).where(
+                        GlobalDevice.id == device_id,  # type: ignore[arg-type]
+                        GlobalDevice.skill_id == skill_uuid,  # type: ignore[arg-type]
+                    )
+                )
+                device = result.scalar_one_or_none()
+
+                if not device:
+                    self.logger.warning("Device %s not found or doesn't belong to this skill", device_id)
+                    return None
+
+                # Update allowed fields
+                for key, value in updates.items():
+                    if hasattr(device, key):
+                        setattr(device, key, value)
+
+                device.updated_at = datetime.now()
+                await session.commit()
+                await session.refresh(device)
+
+            await self._publish_device_update()
+            self.logger.info("Updated device '%s' (id=%s)", device.name, device.id)
+            return device
+
+        except Exception as e:
+            self.logger.error("Failed to update device %s: %s", device_id, e, exc_info=True)
+            return None
+
+    async def delete_device(self, device_id: UUID) -> bool:
+        """Delete device and publish MQTT notification.
+
+        Args:
+            device_id: Device UUID to delete
+
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        try:
+            # Convert skill_id to UUID (skill_id from config is a string)
+            skill_uuid = (
+                UUID(self.config_obj.skill_id)
+                if isinstance(self.config_obj.skill_id, str)
+                else self.config_obj.skill_id
+            )
+
+            async with AsyncSession(self.engine) as session:
+                result = await session.execute(
+                    select(GlobalDevice).where(
+                        GlobalDevice.id == device_id,  # type: ignore[arg-type]
+                        GlobalDevice.skill_id == skill_uuid,  # type: ignore[arg-type]
+                    )
+                )
+                device = result.scalar_one_or_none()
+
+                if not device:
+                    self.logger.warning("Device %s not found or doesn't belong to this skill", device_id)
+                    return False
+
+                device_name = device.name
+                await session.delete(device)
+                await session.commit()
+
+            await self._publish_device_update()
+            self.logger.info("Deleted device '%s' (id=%s)", device_name, device_id)
+            return True
+
+        except Exception as e:
+            self.logger.error("Failed to delete device %s: %s", device_id, e, exc_info=True)
+            return False
+
+    async def get_skill_devices(self) -> list[GlobalDevice]:
+        """Get all devices belonging to this skill.
+
+        Returns:
+            List of GlobalDevice instances for this skill, or empty list on error
+        """
+        try:
+            # Convert skill_id to UUID (skill_id from config is a string)
+            skill_uuid = (
+                UUID(self.config_obj.skill_id)
+                if isinstance(self.config_obj.skill_id, str)
+                else self.config_obj.skill_id
+            )
+
+            async with AsyncSession(self.engine) as session:
+                result = await session.execute(
+                    select(GlobalDevice).where(GlobalDevice.skill_id == skill_uuid)  # type: ignore[arg-type]
+                )
+                return list(result.scalars().all())
+
+        except Exception as e:
+            self.logger.error("Failed to get skill devices: %s", e, exc_info=True)
+            return []
+
+    async def _publish_device_update(self) -> None:
+        """Publish MQTT notification for device cache invalidation.
+
+        Sends an empty message to assistant/global_device_update topic to trigger
+        the intent engine to refresh its device cache.
+        """
+        try:
+            await self.mqtt_client.publish(self.config_obj.device_update_topic, payload="", qos=1)
+            self.logger.debug("Published device update notification to %s", self.config_obj.device_update_topic)
+
+        except Exception as e:
+            self.logger.error("Failed to publish device update notification: %s", e, exc_info=True)

--- a/src/private_assistant_commons/database/models.py
+++ b/src/private_assistant_commons/database/models.py
@@ -36,9 +36,10 @@ Example:
 """
 
 from datetime import datetime
+from typing import Any
 from uuid import UUID, uuid4
 
-from sqlalchemy import ARRAY, Column, String
+from sqlalchemy import ARRAY, JSON, Column, String
 from sqlmodel import Field, SQLModel
 
 
@@ -127,6 +128,7 @@ class GlobalDevice(SQLModel, table=True):
         device_type_id: Foreign key to the device type
         name: Human-readable device name
         pattern: List of pattern strings for matching natural language commands
+        device_attributes: Skill-specific metadata (MQTT paths, templates, state mappings, etc.)
         room_id: Optional foreign key to the room where device is located
         skill_id: Foreign key to the skill that manages this device
         created_at: Timestamp when the device was registered
@@ -144,6 +146,9 @@ class GlobalDevice(SQLModel, table=True):
     device_type_id: UUID = Field(foreign_key="device_types.id", index=True)
     name: str = Field(index=True)
     pattern: list[str] = Field(sa_column=Column(ARRAY(String)))
+    device_attributes: dict[str, Any] | None = Field(
+        default=None, sa_column=Column(JSON), description="Skill-specific device metadata (MQTT paths, templates, etc.)"
+    )
 
     # Foreign key relationships
     room_id: UUID | None = Field(default=None, foreign_key="rooms.id", index=True)

--- a/src/private_assistant_commons/skill_config.py
+++ b/src/private_assistant_commons/skill_config.py
@@ -49,10 +49,19 @@ class SkillConfig(BaseModel):
     intent_analysis_result_topic: str = "assistant/intent_engine/result"
     broadcast_topic: str = "assistant/comms_bridge/broadcast"
     intent_cache_size: int = Field(default=1000, description="Maximum number of intent analysis results to cache")
+    device_update_topic: str = Field(
+        default="assistant/global_device_update",
+        description="MQTT topic for device registry update notifications",
+    )
 
     @property
     def feedback_topic(self) -> str:
         return f"{self.base_topic}/{self.client_id}/feedback"
+
+    @property
+    def skill_id(self) -> str:
+        """Get skill identifier (alias for client_id for DeviceRegistryMixin compatibility)."""
+        return self.client_id
 
 
 def combine_yaml_files(file_paths: list[Path]) -> dict[str, Any]:

--- a/tests/test_device_registry_mixin.py
+++ b/tests/test_device_registry_mixin.py
@@ -1,0 +1,232 @@
+"""Tests for DeviceRegistryMixin."""
+
+import unittest
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+from private_assistant_commons import skill_config
+from private_assistant_commons.base_skill import BaseSkill
+from private_assistant_commons.database import DeviceRegistryMixin, GlobalDevice
+
+
+# Concrete test skill with mixin
+class TestSkillWithRegistry(BaseSkill, DeviceRegistryMixin):
+    """Test skill implementing DeviceRegistryMixin."""
+
+    async def calculate_certainty(self, intent_request: Any) -> float:  # noqa: ARG002
+        return 1.0
+
+    async def process_request(self, intent_request: Any) -> None:
+        pass
+
+    async def skill_preparations(self) -> None:
+        pass
+
+
+class TestDeviceRegistryMixin(unittest.IsolatedAsyncioTestCase):
+    """Test suite for DeviceRegistryMixin."""
+
+    async def asyncSetUp(self):
+        """Set up test fixtures."""
+        # Mock dependencies
+        self.mock_mqtt_client = AsyncMock()
+        self.mock_task_group = AsyncMock()
+        self.mock_engine = Mock()
+
+        # Mock config
+        self.mock_config = Mock(spec=skill_config.SkillConfig)
+        self.mock_config.client_id = "test_skill"
+        self.skill_uuid = uuid.uuid4()
+        self.mock_config.skill_id = str(self.skill_uuid)  # skill_id is string UUID
+        self.mock_config.intent_cache_size = 1000
+        self.mock_config.device_update_topic = "assistant/global_device_update"
+
+        # Create skill instance with mocked engine
+        self.skill = TestSkillWithRegistry(
+            config_obj=self.mock_config,
+            mqtt_client=self.mock_mqtt_client,
+            task_group=self.mock_task_group,
+            engine=self.mock_engine,
+        )
+
+        # Test UUIDs
+        self.device_id = uuid.uuid4()
+        self.device_type_id = uuid.uuid4()
+        self.room_id = uuid.uuid4()
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    async def test_register_device_success(self, mock_session_class):
+        """Test successful device registration."""
+        # Mock session and database operations
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        # Call register_device
+        _device = await self.skill.register_device(
+            name="test lamp",
+            device_type_id=self.device_type_id,
+            pattern=["test lamp", "lamp"],
+            device_attributes={"mqtt_path": "test/lamp"},
+            room_id=self.room_id,
+        )
+
+        # Verify session operations
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_awaited_once()
+        mock_session.refresh.assert_awaited_once()
+
+        # Verify MQTT notification
+        self.mock_mqtt_client.publish.assert_awaited_once_with(
+            "assistant/global_device_update", payload="", qos=1
+        )
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    @patch("private_assistant_commons.database.device_registry.select")
+    async def test_update_device_success(self, _mock_select, mock_session_class):
+        """Test successful device update."""
+        # Mock session and result
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        # Mock device from database
+        mock_device = Mock(spec=GlobalDevice)
+        mock_device.id = self.device_id
+        mock_device.name = "old name"
+        mock_device.pattern = ["old"]
+
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = mock_device
+        mock_session.execute.return_value = mock_result
+
+        # Call update_device
+        _device = await self.skill.update_device(self.device_id, name="new name", pattern=["new pattern"])
+
+        # Verify update
+        assert mock_device.name == "new name"
+        assert mock_device.pattern == ["new pattern"]
+        mock_session.commit.assert_awaited_once()
+
+        # Verify MQTT notification
+        self.mock_mqtt_client.publish.assert_awaited_once()
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    @patch("private_assistant_commons.database.device_registry.select")
+    async def test_update_device_not_found(self, _mock_select, mock_session_class):
+        """Test update when device not found."""
+        # Mock session with no device found
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        # Call update_device
+        device = await self.skill.update_device(self.device_id, name="new name")
+
+        # Verify returns None and no commit
+        assert device is None
+        mock_session.commit.assert_not_awaited()
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    @patch("private_assistant_commons.database.device_registry.select")
+    async def test_delete_device_success(self, _mock_select, mock_session_class):
+        """Test successful device deletion."""
+        # Mock session and device
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_device = Mock(spec=GlobalDevice)
+        mock_device.id = self.device_id
+        mock_device.name = "test lamp"
+
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = mock_device
+        mock_session.execute.return_value = mock_result
+
+        # Call delete_device
+        success = await self.skill.delete_device(self.device_id)
+
+        # Verify deletion
+        assert success is True
+        mock_session.delete.assert_awaited_once_with(mock_device)
+        mock_session.commit.assert_awaited_once()
+
+        # Verify MQTT notification
+        self.mock_mqtt_client.publish.assert_awaited_once()
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    @patch("private_assistant_commons.database.device_registry.select")
+    async def test_delete_device_not_found(self, _mock_select, mock_session_class):
+        """Test delete when device not found."""
+        # Mock session with no device
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_result = Mock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        # Call delete_device
+        success = await self.skill.delete_device(self.device_id)
+
+        # Verify returns False and no delete
+        assert success is False
+        mock_session.delete.assert_not_awaited()
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    @patch("private_assistant_commons.database.device_registry.select")
+    async def test_get_skill_devices(self, _mock_select, mock_session_class):
+        """Test getting all skill devices."""
+        # Mock session and devices
+        mock_session = AsyncMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_device1 = Mock(spec=GlobalDevice, name="device1")
+        mock_device2 = Mock(spec=GlobalDevice, name="device2")
+
+        expected_device_count = 2
+        mock_result = Mock()
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = [mock_device1, mock_device2]
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        # Call get_skill_devices
+        devices = await self.skill.get_skill_devices()
+
+        # Verify results
+        assert len(devices) == expected_device_count
+        assert devices == [mock_device1, mock_device2]
+
+    @patch("private_assistant_commons.database.device_registry.AsyncSession")
+    async def test_register_device_error_handling(self, mock_session_class):
+        """Test error handling in register_device."""
+        # Mock session that raises exception
+        mock_session = AsyncMock()
+        mock_session.commit.side_effect = Exception("Database error")
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        # Call register_device
+        device = await self.skill.register_device(
+            name="test lamp", device_type_id=self.device_type_id, pattern=["test"]
+        )
+
+        # Verify returns None on error
+        assert device is None
+
+    async def test_mqtt_notification_error_handling(self):
+        """Test MQTT notification error handling."""
+        # Mock MQTT client to raise exception
+        self.mock_mqtt_client.publish.side_effect = Exception("MQTT error")
+
+        # Call _publish_device_update directly
+        await self.skill._publish_device_update()
+
+        # Should not raise exception, just log error
+        self.mock_mqtt_client.publish.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -370,14 +370,18 @@ wheels = [
 
 [[package]]
 name = "private-assistant-commons"
-version = "4.3.0"
+version = "4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiomqtt" },
-    { name = "asyncpg" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+]
+
+[package.optional-dependencies]
+database = [
+    { name = "asyncpg" },
     { name = "sqlmodel" },
 ]
 
@@ -397,12 +401,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiomqtt", specifier = "~=2.4.0" },
-    { name = "asyncpg", specifier = "~=0.30.0" },
+    { name = "asyncpg", marker = "extra == 'database'", specifier = "~=0.30.0" },
     { name = "pydantic", specifier = "~=2.9.2" },
     { name = "pyyaml", specifier = "~=6.0.1" },
     { name = "rich", specifier = "~=13.9.4" },
-    { name = "sqlmodel", specifier = "~=0.0.25" },
+    { name = "sqlmodel", marker = "extra == 'database'", specifier = "~=0.0.25" },
 ]
+provides-extras = ["database"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Add device_attributes JSON field to GlobalDevice model for skill-specific metadata
- Add DeviceRegistryMixin for standardized device CRUD operations across skills
- Add engine property to BaseSkill with validation (raises error if not configured)
- Add skill_id property to SkillConfig (alias for client_id)
- Add configurable device_update_topic to SkillConfig (default: assistant/global_device_update)
- Move sqlmodel and asyncpg to optional [database] extra
- Skills needing database features import from private_assistant_commons.database
- Publish MQTT notifications on device updates for cache invalidation
- Add comprehensive tests for device registry functionality

Install with database support: pip install private-assistant-commons[database]

closes #81