### PR TITLE
feat: :card_file_box: add regex support to keywords and remove hints table

### DIFF
--- a/migrations/001_add_skill_help_text_and_intents.sql
+++ b/migrations/001_add_skill_help_text_and_intents.sql
@@ -1,0 +1,28 @@
+-- Migration: Add help_text to skills table and create skill_intents junction table
+-- Date: 2026-01-29
+-- Description: Adds help_text field for skill documentation and creates skill_intents
+--              table to track which intents each skill supports.
+
+-- Add help_text column to existing skills table
+ALTER TABLE skills
+ADD COLUMN IF NOT EXISTS help_text TEXT;
+
+-- Create skill_intents junction table
+CREATE TABLE IF NOT EXISTS skill_intents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    skill_id UUID NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    intent_pattern_id UUID NOT NULL REFERENCES intent_patterns(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- Ensure unique skill-intent combinations
+    CONSTRAINT skill_intent_unique UNIQUE (skill_id, intent_pattern_id)
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_skill_intents_skill_id ON skill_intents(skill_id);
+CREATE INDEX IF NOT EXISTS idx_skill_intents_intent_pattern_id ON skill_intents(intent_pattern_id);
+
+-- Add comment for documentation
+COMMENT ON TABLE skill_intents IS 'Junction table linking skills to their supported intent patterns for documentation and introspection';
+COMMENT ON COLUMN skills.help_text IS 'Human-readable description of skill capabilities for help system';

--- a/migrations/001_add_skill_help_text_and_intents_rollback.sql
+++ b/migrations/001_add_skill_help_text_and_intents_rollback.sql
@@ -1,0 +1,10 @@
+-- Rollback: Remove help_text from skills table and drop skill_intents table
+-- Date: 2026-01-29
+-- Description: Reverts migration 001 - removes skill_intents table and help_text column
+
+-- Drop skill_intents table (CASCADE will drop dependent objects if any)
+DROP TABLE IF EXISTS skill_intents CASCADE;
+
+-- Remove help_text column from skills table
+ALTER TABLE skills
+DROP COLUMN IF EXISTS help_text;

--- a/migrations/002_add_is_regex_remove_hints.sql
+++ b/migrations/002_add_is_regex_remove_hints.sql
@@ -1,0 +1,17 @@
+-- Migration: Add is_regex to intent_pattern_keywords and remove intent_pattern_hints
+-- Date: 2026-01-29
+-- Description: Adds is_regex field to support regex patterns in keywords.
+--              Removes intent_pattern_hints table as hints are no longer used.
+
+-- Add is_regex column to intent_pattern_keywords table
+ALTER TABLE intent_pattern_keywords
+ADD COLUMN IF NOT EXISTS is_regex BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Create index on is_regex for performance
+CREATE INDEX IF NOT EXISTS idx_intent_pattern_keywords_is_regex ON intent_pattern_keywords(is_regex);
+
+-- Drop intent_pattern_hints table (CASCADE will handle foreign key dependencies)
+DROP TABLE IF EXISTS intent_pattern_hints CASCADE;
+
+-- Add comment for documentation
+COMMENT ON COLUMN intent_pattern_keywords.is_regex IS 'Whether the keyword should be treated as a regex pattern';

--- a/migrations/002_add_is_regex_remove_hints_rollback.sql
+++ b/migrations/002_add_is_regex_remove_hints_rollback.sql
@@ -1,0 +1,27 @@
+-- Rollback: Remove is_regex from intent_pattern_keywords and recreate intent_pattern_hints
+-- Date: 2026-01-29
+-- Description: Reverts migration 002 - removes is_regex column and recreates hints table
+-- WARNING: This rollback will recreate the hints table structure but cannot restore data
+
+-- Remove is_regex column from intent_pattern_keywords table
+ALTER TABLE intent_pattern_keywords
+DROP COLUMN IF EXISTS is_regex;
+
+-- Recreate intent_pattern_hints table (structure only, data cannot be restored)
+CREATE TABLE IF NOT EXISTS intent_pattern_hints (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    pattern_id UUID NOT NULL REFERENCES intent_patterns(id) ON DELETE CASCADE,
+    hint TEXT NOT NULL,
+    weight DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- Indexes for performance
+    CONSTRAINT fk_intent_pattern_hints_pattern FOREIGN KEY (pattern_id) REFERENCES intent_patterns(id) ON DELETE CASCADE
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_intent_pattern_hints_pattern_id ON intent_pattern_hints(pattern_id);
+CREATE INDEX IF NOT EXISTS idx_intent_pattern_hints_hint ON intent_pattern_hints(hint);
+
+-- Add comment for documentation
+COMMENT ON TABLE intent_pattern_hints IS 'Context hints for intent pattern confidence boosting (recreated by rollback - data not restored)';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,74 @@
+# Database Migrations
+
+This directory contains SQL migration scripts for the Private Assistant Commons database schema.
+
+## Migration Files
+
+### 001_add_skill_help_text_and_intents.sql
+
+**Purpose:** Adds skill help text and intent tracking capabilities
+
+**Changes:**
+- Adds `help_text` column to `skills` table (TEXT, nullable)
+- Creates `skill_intents` junction table linking skills to intent patterns
+- Adds indexes on foreign key columns for query performance
+- Ensures unique skill-intent combinations via constraint
+
+**Rollback:** Use `001_add_skill_help_text_and_intents_rollback.sql`
+
+## Applying Migrations
+
+### Manual Application
+
+Connect to your PostgreSQL database and run:
+
+```bash
+psql -h localhost -U your_user -d your_database -f migrations/001_add_skill_help_text_and_intents.sql
+```
+
+### Using Python (psycopg)
+
+```python
+from pathlib import Path
+import asyncpg
+
+async def apply_migration():
+    conn = await asyncpg.connect(
+        host='localhost',
+        user='your_user',
+        password='your_password',
+        database='your_database'
+    )
+
+    migration_path = Path('migrations/001_add_skill_help_text_and_intents.sql')
+    migration_sql = migration_path.read_text()
+
+    await conn.execute(migration_sql)
+    await conn.close()
+```
+
+## Rolling Back Migrations
+
+To revert a migration, run the corresponding rollback script:
+
+```bash
+psql -h localhost -U your_user -d your_database -f migrations/001_add_skill_help_text_and_intents_rollback.sql
+```
+
+## Migration Checklist
+
+Before applying a migration to production:
+
+- [ ] Test migration on a development database
+- [ ] Verify all dependent applications are updated
+- [ ] Back up production database
+- [ ] Apply migration during maintenance window
+- [ ] Verify application functionality
+- [ ] Keep rollback script ready
+
+## Notes
+
+- All migrations use `IF NOT EXISTS` / `IF EXISTS` for idempotency
+- Foreign keys include `ON DELETE CASCADE` for automatic cleanup
+- UUIDs are generated using PostgreSQL's `gen_random_uuid()`
+- Timestamps use `TIMESTAMP WITHOUT TIME ZONE` for consistency

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -16,6 +16,19 @@ This directory contains SQL migration scripts for the Private Assistant Commons 
 
 **Rollback:** Use `001_add_skill_help_text_and_intents_rollback.sql`
 
+### 002_add_is_regex_remove_hints.sql
+
+**Purpose:** Add regex support to keywords and remove hints table
+
+**Changes:**
+- Adds `is_regex` column to `intent_pattern_keywords` table (BOOLEAN, default FALSE)
+- Adds index on `is_regex` column for query performance
+- Drops `intent_pattern_hints` table completely (CASCADE)
+
+**Rollback:** Use `002_add_is_regex_remove_hints_rollback.sql`
+
+**Warning:** Rollback recreates hints table structure but cannot restore data
+
 ## Applying Migrations
 
 ### Manual Application

--- a/src/private_assistant_commons/database/__init__.py
+++ b/src/private_assistant_commons/database/__init__.py
@@ -1,7 +1,7 @@
 """Database models for the Private Assistant ecosystem."""
 
 from .device_models import DeviceType, GlobalDevice, Room
-from .intent_pattern_models import IntentPattern, IntentPatternHint, IntentPatternKeyword
+from .intent_pattern_models import IntentPattern, IntentPatternKeyword
 from .postgres_config import PostgresConfig, create_skill_engine
 from .skill_models import Skill, SkillIntent
 
@@ -9,7 +9,6 @@ __all__ = [
     "DeviceType",
     "GlobalDevice",
     "IntentPattern",
-    "IntentPatternHint",
     "IntentPatternKeyword",
     "PostgresConfig",
     "Room",

--- a/src/private_assistant_commons/database/__init__.py
+++ b/src/private_assistant_commons/database/__init__.py
@@ -1,8 +1,9 @@
 """Database models for the Private Assistant ecosystem."""
 
-from .device_models import DeviceType, GlobalDevice, Room, Skill
+from .device_models import DeviceType, GlobalDevice, Room
 from .intent_pattern_models import IntentPattern, IntentPatternHint, IntentPatternKeyword
 from .postgres_config import PostgresConfig, create_skill_engine
+from .skill_models import Skill, SkillIntent
 
 __all__ = [
     "DeviceType",
@@ -13,5 +14,6 @@ __all__ = [
     "PostgresConfig",
     "Room",
     "Skill",
+    "SkillIntent",
     "create_skill_engine",
 ]

--- a/src/private_assistant_commons/database/intent_pattern_models.py
+++ b/src/private_assistant_commons/database/intent_pattern_models.py
@@ -41,9 +41,13 @@ Example:
 """
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .skill_models import SkillIntent
 
 
 class IntentPattern(SQLModel, table=True):
@@ -80,6 +84,7 @@ class IntentPattern(SQLModel, table=True):
     hints: list["IntentPatternHint"] = Relationship(
         back_populates="pattern", sa_relationship_kwargs={"cascade": "all, delete-orphan"}
     )
+    skill_intents: list["SkillIntent"] = Relationship(back_populates="intent_pattern")
 
 
 class IntentPatternKeyword(SQLModel, table=True):

--- a/src/private_assistant_commons/database/skill_models.py
+++ b/src/private_assistant_commons/database/skill_models.py
@@ -1,0 +1,154 @@
+"""Database models for skill management.
+
+This module provides SQLModel table definitions for managing skills and their
+supported intents in the Private Assistant ecosystem.
+
+Skills are components that handle specific types of commands (e.g., switch-skill,
+media-skill). Each skill declares which intents it can handle by linking to the
+IntentPattern table via the SkillIntent junction table.
+
+Example:
+    from private_assistant_commons.database import Skill, SkillIntent
+
+    # Create a skill with help text
+    skill = Skill(name="switch-skill", help_text="Controls switches via MQTT")
+
+    # Link skill to supported intents
+    skill_intent = SkillIntent(skill_id=skill.id, intent_pattern_id=pattern.id)
+
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Self
+from uuid import UUID, uuid4
+
+from sqlmodel import Field, Relationship, SQLModel, select
+
+if TYPE_CHECKING:
+    from .device_models import GlobalDevice
+    from .intent_pattern_models import IntentPattern
+
+
+class Skill(SQLModel, table=True):
+    """Skill model for tracking which skill owns each device.
+
+    Skills are components that manage specific types of devices (e.g., switch-skill,
+    media-skill). Each device must be associated with exactly one skill that handles
+    its operations.
+
+    Attributes:
+        id: Unique identifier for the skill
+        name: Unique skill name (e.g., "switch-skill", "media-skill")
+        help_text: Optional description of skill capabilities for help system
+        created_at: Timestamp when the skill was registered
+        updated_at: Timestamp when the skill was last modified
+
+    """
+
+    __tablename__ = "skills"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    name: str = Field(unique=True, index=True)
+    help_text: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    # Relationships
+    devices: list["GlobalDevice"] = Relationship(back_populates="skill")
+    skill_intents: list["SkillIntent"] = Relationship(back_populates="skill")
+
+    @classmethod
+    async def get_by_name(cls, session, name: str) -> Self | None:
+        """Find skill by name.
+
+        Args:
+            session: AsyncSession for database operations
+            name: Skill name to search for
+
+        Returns:
+            Skill instance if found, None otherwise
+
+        """
+        result = await session.exec(select(cls).where(cls.name == name))
+        return result.first()  # type: ignore[no-any-return]
+
+    @classmethod
+    async def ensure_exists(cls, session, name: str, help_text: str | None = None) -> Self:
+        """Ensure skill exists in database, creating if necessary (idempotent).
+
+        Args:
+            session: AsyncSession for database operations
+            name: Skill name to ensure exists
+            help_text: Optional description of skill capabilities for help system
+
+        Returns:
+            Skill instance (existing or newly created)
+
+        """
+        skill = await cls.get_by_name(session, name)
+        if skill is None:
+            skill = cls(name=name, help_text=help_text)
+            session.add(skill)
+        # Update help_text if provided and different
+        elif help_text is not None and skill.help_text != help_text:
+            skill.help_text = help_text
+            skill.updated_at = datetime.now()
+            session.add(skill)
+
+        await session.commit()
+        await session.refresh(skill)
+        return skill
+
+
+class SkillIntent(SQLModel, table=True):
+    """Junction table linking skills to their supported intents.
+
+    This table stores which intents each skill can handle by referencing the
+    IntentPattern table. It mirrors the runtime supported_intents dict for
+    documentation and introspection purposes.
+
+    Attributes:
+        id: Unique identifier
+        skill_id: Foreign key to skills table
+        intent_pattern_id: Foreign key to intent_patterns table
+        created_at: Timestamp when registered
+        updated_at: Timestamp when last modified
+
+    """
+
+    __tablename__ = "skill_intents"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    skill_id: UUID = Field(foreign_key="skills.id", index=True)
+    intent_pattern_id: UUID = Field(foreign_key="intent_patterns.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    # Relationships
+    skill: Skill = Relationship(back_populates="skill_intents")
+    intent_pattern: "IntentPattern" = Relationship(back_populates="skill_intents")
+
+    @classmethod
+    async def upsert(cls, session, skill_id: UUID, intent_pattern_id: UUID) -> Self:
+        """Create skill-intent mapping if it doesn't exist (idempotent).
+
+        Args:
+            session: AsyncSession for database operations
+            skill_id: UUID of the skill
+            intent_pattern_id: UUID of the intent pattern
+
+        Returns:
+            SkillIntent instance (existing or newly created)
+
+        """
+        statement = select(cls).where(cls.skill_id == skill_id, cls.intent_pattern_id == intent_pattern_id)
+        result = await session.exec(statement)
+        skill_intent = result.first()
+
+        if skill_intent is None:
+            skill_intent = cls(skill_id=skill_id, intent_pattern_id=intent_pattern_id)
+            session.add(skill_intent)
+            await session.commit()
+            await session.refresh(skill_intent)
+
+        return skill_intent  # type: ignore[no-any-return]

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -10,7 +10,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from private_assistant_commons.database import (
     IntentPattern,
-    IntentPatternHint,
     IntentPatternKeyword,
     Skill,
     SkillIntent,
@@ -28,7 +27,6 @@ async def engine():
         tables = [
             IntentPattern.__table__,
             IntentPatternKeyword.__table__,
-            IntentPatternHint.__table__,
             Skill.__table__,
             SkillIntent.__table__,
         ]
@@ -88,7 +86,7 @@ class TestIntentPattern:
         assert pattern.description == "Turn off devices"
 
     async def test_intent_pattern_with_relationships(self, session: AsyncSession):
-        """Test intent pattern with keywords and hints relationships."""
+        """Test intent pattern with keywords relationships."""
         pattern = IntentPattern(intent_type="device.on", description="Turn on devices")
         session.add(pattern)
         await session.commit()
@@ -100,24 +98,16 @@ class TestIntentPattern:
         keyword3 = IntentPatternKeyword(pattern_id=pattern.id, keyword="off", keyword_type="negative")
         session.add_all([keyword1, keyword2, keyword3])
 
-        # Add hints
-        hint1 = IntentPatternHint(pattern_id=pattern.id, hint="light")
-        hint2 = IntentPatternHint(pattern_id=pattern.id, hint="lamp")
-        session.add_all([hint1, hint2])
-
         await session.commit()
 
         # Reload pattern with relationships
         result = await session.exec(
-            select(IntentPattern)
-            .where(IntentPattern.id == pattern.id)
-            .options(selectinload(IntentPattern.keywords), selectinload(IntentPattern.hints))  # type: ignore[arg-type]
+            select(IntentPattern).where(IntentPattern.id == pattern.id).options(selectinload(IntentPattern.keywords))  # type: ignore[arg-type]
         )
         pattern = result.one()
 
         # Verify relationships
         assert len(pattern.keywords) == 3
-        assert len(pattern.hints) == 2
 
         # Verify keyword types
         primary_keywords = [kw for kw in pattern.keywords if kw.keyword_type == "primary"]
@@ -126,41 +116,34 @@ class TestIntentPattern:
         assert len(negative_keywords) == 1
 
     async def test_intent_pattern_cascade_delete(self, session: AsyncSession):
-        """Test that deleting a pattern cascades to keywords and hints."""
+        """Test that deleting a pattern cascades to keywords."""
         pattern = IntentPattern(intent_type="device.on")
         session.add(pattern)
         await session.commit()
         await session.refresh(pattern)
 
-        # Add keywords and hints
+        # Add keywords
         keyword = IntentPatternKeyword(pattern_id=pattern.id, keyword="turn on")
-        hint = IntentPatternHint(pattern_id=pattern.id, hint="light")
-        session.add_all([keyword, hint])
+        session.add(keyword)
         await session.commit()
 
         pattern_id = pattern.id
 
-        # Verify they exist
+        # Verify keyword exists
         kw_result = await session.exec(
             select(IntentPatternKeyword).where(IntentPatternKeyword.pattern_id == pattern_id)
         )
         assert len(list(kw_result.all())) == 1
 
-        hint_result = await session.exec(select(IntentPatternHint).where(IntentPatternHint.pattern_id == pattern_id))
-        assert len(list(hint_result.all())) == 1
-
         # Delete the pattern
         await session.delete(pattern)
         await session.commit()
 
-        # Verify keywords and hints are deleted
+        # Verify keywords are deleted
         kw_result = await session.exec(
             select(IntentPatternKeyword).where(IntentPatternKeyword.pattern_id == pattern_id)
         )
         assert len(list(kw_result.all())) == 0
-
-        hint_result = await session.exec(select(IntentPatternHint).where(IntentPatternHint.pattern_id == pattern_id))
-        assert len(list(hint_result.all())) == 0
 
     async def test_intent_pattern_query_by_enabled(self, session: AsyncSession):
         """Test querying patterns by enabled status."""
@@ -203,6 +186,7 @@ class TestIntentPatternKeyword:
         assert keyword.pattern_id == pattern.id
         assert keyword.keyword == "turn on"
         assert keyword.keyword_type == "primary"
+        assert keyword.is_regex is False
         assert keyword.weight == 1.0
         assert keyword.created_at is not None
 
@@ -271,89 +255,40 @@ class TestIntentPatternKeyword:
         assert len(negative_keywords) == 1
         assert negative_keywords[0].keyword == "off"
 
-
-class TestIntentPatternHint:
-    """Test IntentPatternHint model."""
-
-    async def test_hint_creation_minimal(self, session: AsyncSession):
-        """Test creating a hint with minimal required fields."""
+    async def test_keyword_with_regex(self, session: AsyncSession):
+        """Test creating keywords with regex patterns."""
         pattern = IntentPattern(intent_type="device.on")
         session.add(pattern)
         await session.commit()
         await session.refresh(pattern)
 
-        hint = IntentPatternHint(pattern_id=pattern.id, hint="light")
-        session.add(hint)
-        await session.commit()
-        await session.refresh(hint)
+        # Add literal keyword
+        literal_kw = IntentPatternKeyword(
+            pattern_id=pattern.id, keyword="turn on", keyword_type="primary", is_regex=False
+        )
 
-        assert hint.id is not None
-        assert isinstance(hint.id, uuid.UUID)
-        assert hint.pattern_id == pattern.id
-        assert hint.hint == "light"
-        assert hint.weight == 1.0
-        assert hint.created_at is not None
+        # Add regex keyword
+        regex_kw = IntentPatternKeyword(
+            pattern_id=pattern.id, keyword=r"switch (on|off)", keyword_type="primary", is_regex=True
+        )
 
-    async def test_hint_creation_full(self, session: AsyncSession):
-        """Test creating a hint with all fields."""
-        pattern = IntentPattern(intent_type="device.on")
-        session.add(pattern)
-        await session.commit()
-        await session.refresh(pattern)
-
-        hint_id = uuid.uuid4()
-        hint = IntentPatternHint(id=hint_id, pattern_id=pattern.id, hint="lamp", weight=1.5)
-        session.add(hint)
-        await session.commit()
-        await session.refresh(hint)
-
-        assert hint.id == hint_id
-        assert hint.hint == "lamp"
-        assert hint.weight == 1.5
-
-    async def test_hint_relationship(self, session: AsyncSession):
-        """Test hint relationship with pattern."""
-        pattern = IntentPattern(intent_type="device.on")
-        session.add(pattern)
-        await session.commit()
-        await session.refresh(pattern)
-
-        hint = IntentPatternHint(pattern_id=pattern.id, hint="light")
-        session.add(hint)
-        await session.commit()
-        await session.refresh(hint)
-
-        # Access pattern from hint
-        assert hint.pattern.id == pattern.id
-        assert hint.pattern.intent_type == "device.on"
-
-    async def test_query_hints_by_pattern(self, session: AsyncSession):
-        """Test querying hints for a specific pattern."""
-        pattern1 = IntentPattern(intent_type="device.on")
-        pattern2 = IntentPattern(intent_type="device.off")
-        session.add_all([pattern1, pattern2])
-        await session.commit()
-        await session.refresh(pattern1)
-        await session.refresh(pattern2)
-
-        # Add hints to different patterns
-        hint1 = IntentPatternHint(pattern_id=pattern1.id, hint="light")
-        hint2 = IntentPatternHint(pattern_id=pattern1.id, hint="lamp")
-        hint3 = IntentPatternHint(pattern_id=pattern2.id, hint="device")
-        session.add_all([hint1, hint2, hint3])
+        session.add_all([literal_kw, regex_kw])
         await session.commit()
 
-        # Query hints for pattern1
-        result = await session.exec(select(IntentPatternHint).where(IntentPatternHint.pattern_id == pattern1.id))
-        pattern1_hints = list(result.all())
-        assert len(pattern1_hints) == 2
-        assert {h.hint for h in pattern1_hints} == {"light", "lamp"}
+        # Query all keywords
+        result = await session.exec(select(IntentPatternKeyword).where(IntentPatternKeyword.pattern_id == pattern.id))
+        keywords = list(result.all())
+        assert len(keywords) == 2
 
-        # Query hints for pattern2
-        result = await session.exec(select(IntentPatternHint).where(IntentPatternHint.pattern_id == pattern2.id))
-        pattern2_hints = list(result.all())
-        assert len(pattern2_hints) == 1
-        assert pattern2_hints[0].hint == "device"
+        # Verify is_regex flags
+        literal_keywords = [kw for kw in keywords if not kw.is_regex]
+        regex_keywords = [kw for kw in keywords if kw.is_regex]
+
+        assert len(literal_keywords) == 1
+        assert literal_keywords[0].keyword == "turn on"
+
+        assert len(regex_keywords) == 1
+        assert regex_keywords[0].keyword == r"switch (on|off)"
 
 
 class TestIntentPatternUsageExample:
@@ -361,7 +296,7 @@ class TestIntentPatternUsageExample:
 
     async def test_load_patterns_from_database(self, session: AsyncSession):
         """Test loading patterns as shown in the example usage."""
-        # Create patterns with keywords and hints
+        # Create patterns with keywords
         pattern1 = IntentPattern(intent_type="device.on", enabled=True, priority=10, description="Turn on devices")
         pattern2 = IntentPattern(intent_type="device.off", enabled=True, priority=5, description="Turn off devices")
         pattern3 = IntentPattern(intent_type="device.set", enabled=False, priority=0, description="Set device state")
@@ -372,23 +307,16 @@ class TestIntentPatternUsageExample:
         await session.refresh(pattern3)
 
         # Add keywords to pattern1
-        kw1 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="turn on", keyword_type="primary")
-        kw2 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="switch on", keyword_type="primary")
-        kw3 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="off", keyword_type="negative")
+        kw1 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="turn on", keyword_type="primary", is_regex=False)
+        kw2 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="switch on", keyword_type="primary", is_regex=False)
+        kw3 = IntentPatternKeyword(pattern_id=pattern1.id, keyword="off", keyword_type="negative", is_regex=False)
         session.add_all([kw1, kw2, kw3])
-
-        # Add hints to pattern1
-        hint1 = IntentPatternHint(pattern_id=pattern1.id, hint="light")
-        hint2 = IntentPatternHint(pattern_id=pattern1.id, hint="lamp")
-        session.add_all([hint1, hint2])
 
         await session.commit()
 
         # Load patterns from database (example usage)
         result = await session.exec(
-            select(IntentPattern)
-            .where(IntentPattern.enabled)
-            .options(selectinload(IntentPattern.keywords), selectinload(IntentPattern.hints))  # type: ignore[arg-type]
+            select(IntentPattern).where(IntentPattern.enabled).options(selectinload(IntentPattern.keywords))  # type: ignore[arg-type]
         )
         db_patterns = list(result.all())
 
@@ -401,8 +329,6 @@ class TestIntentPatternUsageExample:
             if db_pattern.intent_type == "device.on":
                 primary_keywords = [kw.keyword for kw in db_pattern.keywords if kw.keyword_type == "primary"]
                 negative_keywords = [kw.keyword for kw in db_pattern.keywords if kw.keyword_type == "negative"]
-                context_hints = [hint.hint for hint in db_pattern.hints]
 
                 assert set(primary_keywords) == {"turn on", "switch on"}
                 assert negative_keywords == ["off"]
-                assert set(context_hints) == {"light", "lamp"}

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -12,6 +12,8 @@ from private_assistant_commons.database import (
     IntentPattern,
     IntentPatternHint,
     IntentPatternKeyword,
+    Skill,
+    SkillIntent,
 )
 
 
@@ -20,13 +22,15 @@ async def engine():
     """Create an in-memory SQLite database engine for testing."""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
 
-    # Create only the intent pattern tables (skip models with ARRAY types)
+    # Create intent pattern and skill tables (skip models with ARRAY types)
     async with engine.begin() as conn:
-        # Get table objects for just the intent pattern models
+        # Get table objects for the intent pattern and skill models
         tables = [
             IntentPattern.__table__,
             IntentPatternKeyword.__table__,
             IntentPatternHint.__table__,
+            Skill.__table__,
+            SkillIntent.__table__,
         ]
         # Create only these specific tables
         await conn.run_sync(lambda sync_conn: IntentPattern.metadata.create_all(sync_conn, tables=tables))

--- a/tests/test_skill_intents.py
+++ b/tests/test_skill_intents.py
@@ -1,0 +1,318 @@
+"""Unit tests for Skill and SkillIntent models."""
+
+import uuid
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from private_assistant_commons.database import IntentPattern, Skill, SkillIntent
+
+
+@pytest_asyncio.fixture
+async def engine():
+    """Create an in-memory SQLite database engine for testing."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+
+    # Create skill, intent_pattern, and skill_intent tables
+    async with engine.begin() as conn:
+        tables = [Skill.__table__, IntentPattern.__table__, SkillIntent.__table__]
+        await conn.run_sync(lambda sync_conn: Skill.metadata.create_all(sync_conn, tables=tables))
+
+    yield engine
+
+    # Cleanup
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(engine: AsyncEngine):
+    """Create a database session for testing."""
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        yield session
+
+
+class TestSkillModel:
+    """Test Skill model with help_text functionality."""
+
+    async def test_skill_creation_minimal(self, session: AsyncSession):
+        """Test creating a skill with minimal required fields."""
+        skill = Skill(name="test-skill")
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        assert skill.id is not None
+        assert isinstance(skill.id, uuid.UUID)
+        assert skill.name == "test-skill"
+        assert skill.help_text is None
+        assert skill.created_at is not None
+        assert skill.updated_at is not None
+
+    async def test_skill_creation_with_help_text(self, session: AsyncSession):
+        """Test creating a skill with help text."""
+        help_text = "Controls lights via Home Assistant MQTT"
+        skill = Skill(name="switch-skill", help_text=help_text)
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        assert skill.id is not None
+        assert skill.name == "switch-skill"
+        assert skill.help_text == help_text
+
+    async def test_skill_get_by_name(self, session: AsyncSession):
+        """Test finding skill by name."""
+        skill = Skill(name="media-skill", help_text="Plays media")
+        session.add(skill)
+        await session.commit()
+
+        found_skill = await Skill.get_by_name(session, "media-skill")
+        assert found_skill is not None
+        assert found_skill.name == "media-skill"
+        assert found_skill.help_text == "Plays media"
+
+        not_found = await Skill.get_by_name(session, "non-existent")
+        assert not_found is None
+
+    async def test_skill_ensure_exists_creates_new(self, session: AsyncSession):
+        """Test ensure_exists creates a new skill if it doesn't exist."""
+        skill = await Skill.ensure_exists(session, "new-skill", help_text="New skill help")
+
+        assert skill.id is not None
+        assert skill.name == "new-skill"
+        assert skill.help_text == "New skill help"
+
+        # Verify it's in the database
+        statement = select(Skill).where(Skill.name == "new-skill")
+        result = await session.exec(statement)
+        found = result.first()
+        assert found is not None
+        assert found.name == "new-skill"
+
+    async def test_skill_ensure_exists_returns_existing(self, session: AsyncSession):
+        """Test ensure_exists returns existing skill without changes."""
+        # Create initial skill
+        original = await Skill.ensure_exists(session, "existing-skill", help_text="Original help")
+        original_id = original.id
+        original_updated = original.updated_at
+
+        # Call ensure_exists again without help_text
+        skill = await Skill.ensure_exists(session, "existing-skill")
+
+        assert skill.id == original_id
+        assert skill.help_text == "Original help"  # Unchanged
+        assert skill.updated_at == original_updated  # Not updated
+
+    async def test_skill_ensure_exists_updates_help_text(self, session: AsyncSession):
+        """Test ensure_exists updates help_text if provided and different."""
+        # Create initial skill
+        original = await Skill.ensure_exists(session, "update-skill", help_text="Old help")
+        original_id = original.id
+
+        # Update with new help_text
+        updated = await Skill.ensure_exists(session, "update-skill", help_text="New help")
+
+        assert updated.id == original_id
+        assert updated.help_text == "New help"
+        assert updated.updated_at >= original.updated_at  # >= because timestamps may be same in fast tests
+
+    async def test_skill_ensure_exists_no_update_same_help_text(self, session: AsyncSession):
+        """Test ensure_exists doesn't update if help_text is the same."""
+        # Create initial skill
+        original = await Skill.ensure_exists(session, "same-skill", help_text="Same help")
+        original_updated = original.updated_at
+
+        # Call with same help_text
+        skill = await Skill.ensure_exists(session, "same-skill", help_text="Same help")
+
+        assert skill.help_text == "Same help"
+        assert skill.updated_at == original_updated  # Not updated
+
+
+class TestSkillIntentModel:
+    """Test SkillIntent junction table model."""
+
+    async def test_skill_intent_creation(self, session: AsyncSession):
+        """Test creating a skill-intent mapping."""
+        # Create an intent pattern first
+        intent_pattern = IntentPattern(intent_type="device.on")
+        session.add(intent_pattern)
+        await session.commit()
+        await session.refresh(intent_pattern)
+
+        # Create a skill
+        skill = Skill(name="test-skill")
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        # Create skill-intent mapping
+        skill_intent = SkillIntent(skill_id=skill.id, intent_pattern_id=intent_pattern.id)
+        session.add(skill_intent)
+        await session.commit()
+        await session.refresh(skill_intent)
+
+        assert skill_intent.id is not None
+        assert isinstance(skill_intent.id, uuid.UUID)
+        assert skill_intent.skill_id == skill.id
+        assert skill_intent.intent_pattern_id == intent_pattern.id
+        assert skill_intent.created_at is not None
+        assert skill_intent.updated_at is not None
+
+    async def test_skill_intent_relationship(self, session: AsyncSession):
+        """Test relationship between Skill and SkillIntent."""
+        # Create intent patterns
+        pattern1 = IntentPattern(intent_type="device.on")
+        pattern2 = IntentPattern(intent_type="device.off")
+        session.add(pattern1)
+        session.add(pattern2)
+        await session.commit()
+        await session.refresh(pattern1)
+        await session.refresh(pattern2)
+
+        # Create skill
+        skill = Skill(name="relationship-skill")
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        # Create multiple skill-intent mappings
+        intent1 = SkillIntent(skill_id=skill.id, intent_pattern_id=pattern1.id)
+        intent2 = SkillIntent(skill_id=skill.id, intent_pattern_id=pattern2.id)
+        session.add(intent1)
+        session.add(intent2)
+        await session.commit()
+
+        # Query intents and verify relationships
+        intent_statement = select(SkillIntent).where(SkillIntent.skill_id == skill.id)
+        intent_result = await session.exec(intent_statement)
+        intents = intent_result.all()
+
+        assert len(intents) == 2
+        assert {i.intent_pattern_id for i in intents} == {pattern1.id, pattern2.id}
+
+    async def test_skill_intent_upsert_creates_new(self, session: AsyncSession):
+        """Test upsert creates new skill-intent mapping."""
+        # Create intent pattern
+        pattern = IntentPattern(intent_type="device.set")
+        session.add(pattern)
+        await session.commit()
+        await session.refresh(pattern)
+
+        # Create skill
+        skill = Skill(name="upsert-skill")
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        # Upsert skill-intent mapping
+        skill_intent = await SkillIntent.upsert(session, skill.id, pattern.id)
+
+        assert skill_intent.id is not None
+        assert skill_intent.skill_id == skill.id
+        assert skill_intent.intent_pattern_id == pattern.id
+
+    async def test_skill_intent_upsert_returns_existing(self, session: AsyncSession):
+        """Test upsert returns existing skill-intent mapping if already exists."""
+        # Create intent pattern
+        pattern = IntentPattern(intent_type="media.play")
+        session.add(pattern)
+        await session.commit()
+        await session.refresh(pattern)
+
+        # Create skill
+        skill = Skill(name="existing-mapping-skill")
+        session.add(skill)
+        await session.commit()
+        await session.refresh(skill)
+
+        # Create initial mapping
+        original = await SkillIntent.upsert(session, skill.id, pattern.id)
+        original_id = original.id
+
+        # Call upsert again - should return existing
+        existing = await SkillIntent.upsert(session, skill.id, pattern.id)
+
+        assert existing.id == original_id
+        assert existing.skill_id == skill.id
+        assert existing.intent_pattern_id == pattern.id
+
+
+class TestSkillIntentIntegration:
+    """Integration tests for skill registration with intents."""
+
+    async def test_skill_with_multiple_intents(self, session: AsyncSession):
+        """Test creating a skill with multiple intent mappings."""
+        # Create intent patterns
+        patterns = []
+        for intent_type in ["device.on", "device.off", "device.set"]:
+            pattern = IntentPattern(intent_type=intent_type)
+            session.add(pattern)
+            patterns.append(pattern)
+        await session.commit()
+        for pattern in patterns:
+            await session.refresh(pattern)
+
+        # Create skill
+        skill = await Skill.ensure_exists(session, "multi-intent-skill", help_text="Handles multiple intents")
+
+        # Add multiple intents
+        for pattern in patterns:
+            await SkillIntent.upsert(session, skill.id, pattern.id)
+
+        # Verify all intents are registered
+        statement = select(SkillIntent).where(SkillIntent.skill_id == skill.id)
+        result = await session.exec(statement)
+        registered_intents = result.all()
+
+        assert len(registered_intents) == 3
+        registered_pattern_ids = {si.intent_pattern_id for si in registered_intents}
+        expected_pattern_ids = {p.id for p in patterns}
+        assert registered_pattern_ids == expected_pattern_ids
+
+    async def test_remove_stale_intents(self, session: AsyncSession):
+        """Test removing intents that are no longer supported."""
+        # Create intent patterns
+        patterns = []
+        for intent_type in ["device.on", "device.off", "device.set"]:
+            pattern = IntentPattern(intent_type=intent_type)
+            session.add(pattern)
+            patterns.append(pattern)
+        await session.commit()
+        for pattern in patterns:
+            await session.refresh(pattern)
+
+        # Create skill
+        skill = await Skill.ensure_exists(session, "remove-intent-skill")
+
+        # Add initial intents
+        for pattern in patterns:
+            await SkillIntent.upsert(session, skill.id, pattern.id)
+
+        # Verify all three exist
+        statement = select(SkillIntent).where(SkillIntent.skill_id == skill.id)
+        result = await session.exec(statement)
+        assert len(result.all()) == 3
+
+        # Remove one intent (simulating skill no longer supporting it)
+        pattern_to_remove = next(p for p in patterns if p.intent_type == "device.set")
+        delete_statement = select(SkillIntent).where(
+            SkillIntent.skill_id == skill.id, SkillIntent.intent_pattern_id == pattern_to_remove.id
+        )
+        delete_result = await session.exec(delete_statement)
+        to_delete = delete_result.first()
+        if to_delete:
+            await session.delete(to_delete)
+            await session.commit()
+
+        # Verify only two remain
+        final_statement = select(SkillIntent).where(SkillIntent.skill_id == skill.id)
+        final_result = await session.exec(final_statement)
+        final_intents = final_result.all()
+
+        assert len(final_intents) == 2
+        remaining_pattern_ids = {si.intent_pattern_id for si in final_intents}
+        expected_pattern_ids = {p.id for p in patterns if p.intent_type != "device.set"}
+        assert remaining_pattern_ids == expected_pattern_ids

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-commons"
-version = "6.0.0"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Add is_regex field to IntentPatternKeyword model to support both literal strings and regex patterns. Remove IntentPatternHint model entirely as hints are no longer used in intent matching.