### PR TITLE
feat: :sparkles: add class attribute for skill help text

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -100,6 +100,24 @@ def add_task(self, coro) -> asyncio.Task:
 ```
 Add a coroutine as a new task to the skill's task group for concurrent execution.
 
+#### Class Attributes
+
+- **help_text** (`str | None`): Class-level attribute for skill help text. Override in subclasses to provide a description of the skill's capabilities for the help system. Automatically registered in the database during `skill_preparations()`. Defaults to `None`.
+
+**Example:**
+```python
+class LightControlSkill(BaseSkill):
+    help_text = "Controls smart lights - turn on/off, adjust brightness, and set colors"
+```
+
+#### Instance Attributes (Configure in `__init__`)
+
+- **supported_intents** (`dict[IntentType, float]`): Map of supported intent types to their minimum confidence thresholds. Set this in your skill's `__init__` method after calling `super().__init__()`.
+
+- **supported_device_types** (`list[str]`): List of device type names this skill supports (e.g., `["light", "switch"]`). Automatically registered in the database during `skill_preparations()`.
+
+- **confidence_modifiers** (`dict[IntentType, list[ConfidenceModifier]]`): Map of target intents to their confidence modifiers for context-aware threshold adjustments.
+
 #### Properties
 - **config_obj** (`SkillConfig`): Skill configuration
 - **mqtt_client** (`aiomqtt.Client`): MQTT client instance

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,6 +19,9 @@ from private_assistant_commons import (
 )
 
 class LightControlSkill(BaseSkill):
+    # Set help text at class level - appears in skill registry for help system
+    help_text = "Controls smart lights - turn on/off, adjust brightness, and set colors"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -79,6 +82,68 @@ class LightControlSkill(BaseSkill):
 
         # Send response back to the user
         await self.send_response(response_text, client_request)
+```
+
+### Skill Configuration
+
+Skills configure themselves through a combination of class attributes and instance attributes:
+
+#### Help Text (Class Attribute)
+
+Provide a description of your skill's capabilities for the help system:
+
+```python
+class LightControlSkill(BaseSkill):
+    help_text = "Controls smart lights - turn on/off, adjust brightness, and set colors"
+```
+
+This text is automatically registered in the database when the skill starts and can be used by help/discovery features. Since help text is constant for all instances of a skill, it's defined as a class attribute.
+
+#### Supported Intents (Instance Attribute)
+
+Configure which intents your skill handles and their confidence thresholds in `__init__`:
+
+```python
+def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+    self.supported_intents = {
+        IntentType.DEVICE_ON: 0.8,
+        IntentType.DEVICE_OFF: 0.8,
+    }
+```
+
+#### Supported Device Types (Instance Attribute)
+
+Declare which device types your skill manages:
+
+```python
+def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+    self.supported_device_types = ["light", "switch", "dimmer"]
+```
+
+These device types are automatically registered in the database during `skill_preparations()`.
+
+#### Confidence Modifiers (Instance Attribute)
+
+Define context-aware threshold adjustments for natural conversation flow:
+
+```python
+def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+    self.confidence_modifiers = {
+        IntentType.DEVICE_OFF: [
+            ConfidenceModifier(
+                trigger_intent=IntentType.DEVICE_ON,
+                lowers_threshold_for=IntentType.DEVICE_OFF,
+                reduced_threshold=0.5,
+                time_window_seconds=300,
+            ),
+        ],
+    }
 ```
 
 ### Running a Skill

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-commons"
-version = "6.1.0"
+version = "6.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Skills can now set help text declaratively as a class attribute instead of overriding skill_preparations(). The ensure_skill_registered() method uses the class attribute as default when no explicit help_text is provided, maintaining full backwards compatibility.